### PR TITLE
Disable spellcheck for new connection form fields

### DIFF
--- a/src/components/SideBars/ConnectionsSideBar/components/ConnectionDialog.tsx
+++ b/src/components/SideBars/ConnectionsSideBar/components/ConnectionDialog.tsx
@@ -52,6 +52,7 @@ const ConnectionsDialog = forwardRef<ConnectionDialogRef, ComponentProps>(
                       className={`flex-grow ${bpTheme}`}
                       placeholder="Name"
                       size={40}
+                      spellCheck={false}
                       {...field}
                     />
                   )}
@@ -75,6 +76,7 @@ const ConnectionsDialog = forwardRef<ConnectionDialogRef, ComponentProps>(
                       className={`flex-grow ${bpTheme}`}
                       placeholder="Host"
                       size={40}
+                      spellCheck={false}
                       {...field}
                     />
                   )}
@@ -110,6 +112,7 @@ const ConnectionsDialog = forwardRef<ConnectionDialogRef, ComponentProps>(
                         className={`flex-grow ${bpTheme}`}
                         placeholder="Database"
                         size={40}
+                        spellCheck={false}
                         {...field}
                       />
                     )}
@@ -148,6 +151,7 @@ const ConnectionsDialog = forwardRef<ConnectionDialogRef, ComponentProps>(
                       className={`flex-grow ${bpTheme}`}
                       placeholder="Username"
                       size={40}
+                      spellCheck={false}
                       {...field}
                     />
                   )}

--- a/src/components/SideBars/ConnectionsSideBar/components/ConnectionDialog.tsx
+++ b/src/components/SideBars/ConnectionsSideBar/components/ConnectionDialog.tsx
@@ -167,6 +167,7 @@ const ConnectionsDialog = forwardRef<ConnectionDialogRef, ComponentProps>(
                       type={showPassword ? "text" : "password"}
                       placeholder="Password"
                       size={40}
+                      spellCheck={false}
                       rightElement={<ShowPasswordButton />}
                       {...field}
                     />

--- a/src/components/SideBars/ConnectionsSideBar/components/ConnectionDialog.tsx
+++ b/src/components/SideBars/ConnectionsSideBar/components/ConnectionDialog.tsx
@@ -52,7 +52,6 @@ const ConnectionsDialog = forwardRef<ConnectionDialogRef, ComponentProps>(
                       className={`flex-grow ${bpTheme}`}
                       placeholder="Name"
                       size={40}
-                      spellCheck={false}
                       {...field}
                     />
                   )}
@@ -95,6 +94,7 @@ const ConnectionsDialog = forwardRef<ConnectionDialogRef, ComponentProps>(
                       onBlur={field.onBlur}
                       onChange={field.onChange}
                       ref={field.ref}
+                      spellCheck={false}
                       value={field.value.toString()}
                     />
                   )}


### PR DESCRIPTION
This disables the spellcheck for:
- Host
- Port
- Database
- Username
- Password (if we show it)

